### PR TITLE
Fixing corner radius clip due to different radius

### DIFF
--- a/src/ms-store-badge.ts
+++ b/src/ms-store-badge.ts
@@ -252,7 +252,7 @@ class MSStoreBadge extends HTMLElement {
 
       img {
         display: block;
-        border-radius: 8px;
+        border-radius: 4.5px;
         transition: 0.35s ease;
       }
 


### PR DESCRIPTION
Style-defined corner radius doesn't match SVG radius, so it ends up clipping the corners.

<img width="536" height="176" alt="image" src="https://github.com/user-attachments/assets/7eff1310-2f0e-46f9-93be-87f646e52791" />
  
<img width="262" height="189" alt="image" src="https://github.com/user-attachments/assets/16290ec6-6e18-460f-83bb-7c86d011806e" />

How it was:
```
//Style
border-radius: 8px;
```

```
//SVG
<rect ... rx="4.5" ... />
```